### PR TITLE
Change for overlay directories methods

### DIFF
--- a/src/main/java/org/jboss/eap/qa/jarest/JarArtifact.java
+++ b/src/main/java/org/jboss/eap/qa/jarest/JarArtifact.java
@@ -25,6 +25,7 @@ package org.jboss.eap.qa.jarest;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -45,10 +46,22 @@ public class JarArtifact extends Artifact {
         }
     }
 
-    public boolean hasOverlayDirectory(int javaVersion) {
+    public boolean hasOverlayDirectoryFor(int javaVersion) {
         try (ZipFile zip = new ZipFile(file.toFile())) {
             return zip.stream()
                     .anyMatch(entry -> entry.getName().contains("META-INF/versions/" + javaVersion));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public boolean hasJustOverlayDirectoriesFor(int... javaVersions) {
+        try (ZipFile zip = new ZipFile(file.toFile())) {
+            return zip.stream()
+                    .filter(entry -> entry.getName().matches("META-INF/versions/\\d(.*)"))
+                    .allMatch(entry -> Arrays.stream(javaVersions)
+                                                .mapToObj(i -> "META-INF/versions/" + i)
+                                                .anyMatch(entry.getName()::contains));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/test/java/org/jboss/eap/qa/jarest/DistributionTestCase.java
+++ b/src/test/java/org/jboss/eap/qa/jarest/DistributionTestCase.java
@@ -49,7 +49,7 @@ public class DistributionTestCase {
                 )
                 .forEach(jar -> {
                             softly.assertThat(
-                                    jar.hasOverlayDirectory(9))
+                                    jar.hasOverlayDirectoryFor(9))
                                     .as("Artifact %s is not expected to be Multi-Release JAR", jar.file())
                                     .isFalse();
                         }
@@ -66,7 +66,7 @@ public class DistributionTestCase {
                 )
                 .forEach(jar -> {
                             softly.assertThat(
-                                    jar.hasOverlayDirectory(9))
+                                    jar.hasOverlayDirectoryFor(9))
                                     .as("Artifact %s is expected to be Multi-Release JAR", jar.file())
                                     .isTrue();
                         }
@@ -99,14 +99,7 @@ public class DistributionTestCase {
         distributionDir.jars()
                 .filter(jar -> jar.hasOverlayDirectory())
                 .forEach(jar -> {
-                            softly.assertThat(
-                                    jar.hasOverlayDirectory(9)
-                                            && ! jar.hasOverlayDirectory(10)
-                                            && ! jar.hasOverlayDirectory(11)
-                                            && ! jar.hasOverlayDirectory(12)
-                                            && ! jar.hasOverlayDirectory(13)
-                                            && ! jar.hasOverlayDirectory(14)
-                                    )
+                            softly.assertThat(jar.hasJustOverlayDirectoriesFor(9))
                                     .as("Artifact %s is expected to be at most versions/9 Multi-Release JAR", jar.file())
                                     .isTrue();
                         }


### PR DESCRIPTION
Change for overlay directories methods

* Introduction of `hasJustOverlayDirectoriesFor` method 
* remane of `hasOverlayDirectory(int javaVersion)` to `hasOverlayDirectoryFor(int javaVersion)`